### PR TITLE
Derive host from keyfile if not set

### DIFF
--- a/eris.pl
+++ b/eris.pl
@@ -206,10 +206,10 @@ my ($sign_host, $sign_pk, $sign_sk) = (undef, undef, undef);
 
 ## Case 1: user-specified keys
 if (ref(app->config->{signing}) eq 'HASH') {
-  $sign_host = app->config->{signing}->{host};
   $sign_sk = readFile app->config->{signing}->{private};
   chomp $sign_sk; # readFile doesn't do this itself
 
+  $sign_host      = app->config->{signing}->{host} // (split(/:/, $sign_sk))[0];
   my $sign_sk64   = +(split /:/, $sign_sk)[-1];
   my $sign_skno64 = decode_base64($sign_sk64);
 

--- a/readme.org
+++ b/readme.org
@@ -329,6 +329,8 @@ with:
 }
 #+END_SRC
 
+The host attribute can be omitted when the private key is in the form of ~host:key~.
+
 *** Support for private users via HTTP authentication
 
 You can add support for basic HTTP authentication via the ~users~ field in


### PR DESCRIPTION
Instead of throwing 500s all around the place, default to a host
specified in the key file if not set in the config file.

This essentially lets you not set signing=>host if your private key
already specifies the host name.

Signed-off-by: Janne Heß <janne@hess.ooo>

###### Motivation for this change

Describe the motivation for this change, why it was written a particular way,
alternative options that you considered, and generally as much context as
possible.

**NOTE**: Do **NOT** submit security-related patches as public pull requests.
To submit security-relevant fixes or patches, a security advisory should be
created. See [SECURITY.md](https://github.com/thoughtpolice/eris/blob/master/.github/SECURITY.md)
as well as [SUPPORT.md](https://github.com/thoughtpolice/eris/blob/master/.github/SUPPORT.md)
for more information.

###### Related issue(s)

Include any related issues here, and how this change might fix, impact, or
relate to them in general.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Compiled all jobs with `nix build -f release.nix`
- [x] Ran all tests with `nix build -f release.nix test`
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/thoughtpolice/eris/blob/master/.github/CONTRIBUTING.md).

---

